### PR TITLE
Remove link to camera device from RasterPictureFacet

### DIFF
--- a/case_exiftool/__init__.py
+++ b/case_exiftool/__init__.py
@@ -269,15 +269,6 @@ WHERE {
           n_raster_picture_facet
         ))
 
-        # TODO This property has an open question on its usage.
-        # https://unifiedcyberontology.atlassian.net/browse/OC-72
-        if not n_camera is None:
-            out_graph.add((
-              n_raster_picture_facet,
-              NS_UCO_OBSERVABLE.camera,
-              n_camera
-            ))
-
         if mime_type in mime_type_to_picture_type:
             l_picture_type = rdflib.Literal(mime_type_to_picture_type[mime_type])
             out_graph.add((

--- a/tests/govdocs1/files/799/987/analysis.json
+++ b/tests/govdocs1/files/799/987/analysis.json
@@ -249,9 +249,6 @@
                 },
                 {
                     "@type": "uco-observable:RasterPicture",
-                    "uco-observable:camera": {
-                        "@id": "kb:device-e49850a6-8b3e-5b9b-bc6a-0d003dd23c95"
-                    },
                     "uco-observable:pictureHeight": {
                         "@type": "xsd:integer",
                         "@value": "1960"

--- a/tests/govdocs1/files/799/987/analysis.ttl
+++ b/tests/govdocs1/files/799/987/analysis.ttl
@@ -879,7 +879,6 @@ VZEl1KV42DIcYKnjoKxm00ddKLUtUf/Z
 		] ,
 		[
 			a uco-observable:RasterPicture ;
-			uco-observable:camera kb:device-e49850a6-8b3e-5b9b-bc6a-0d003dd23c95 ;
 			uco-observable:pictureHeight "1960"^^xsd:integer ;
 			uco-observable:pictureType "jpg" ;
 			uco-observable:pictureWidth "3008"^^xsd:integer ;


### PR DESCRIPTION
On inquiry, I was informed this practice was incorrect.

References:
* [UCO OC-72] observable:camera needs to be explained relative to
  Relationship objects

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>