### PR TITLE
Use pip -e flag

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -30,7 +30,6 @@ all: \
 
 .venv.done.log: \
   $(top_srcdir)/.git_submodule_init.done.log \
-  $(top_srcdir)/case_exiftool/__init__.py \
   $(top_srcdir)/dependencies/CASE-Utilities-Python/tests/requirements.txt \
   $(top_srcdir)/setup.cfg \
   $(top_srcdir)/setup.py
@@ -52,7 +51,9 @@ all: \
 	    --requirement $(top_srcdir)/dependencies/CASE-Utilities-Python/tests/requirements.txt
 	source venv/bin/activate \
 	  && cd $(top_srcdir) \
-	    && python3 setup.py install
+	    && pip install \
+	      --editable \
+	      .
 	touch $@
 
 check: \

--- a/tests/govdocs1/files/799/987/Makefile
+++ b/tests/govdocs1/files/799/987/Makefile
@@ -57,6 +57,7 @@ analysis.json: \
 
 analysis.ttl: \
   $(tests_srcdir)/.venv.done.log \
+  $(top_srcdir)/case_exiftool/__init__.py \
   799987_printConv.xml \
   799987_raw.xml
 	export DEMO_UUID_REQUESTING_NONRANDOM=NONRANDOM_REQUESTED \


### PR DESCRIPTION
This speeds local 'make check' round trips while developing, though at
the trade of having to push dependencies into more localized Make
recipes.

References:
* https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-e

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>