### PR TITLE
Adopt ExifTool 12.26 and later

### DIFF
--- a/case_exiftool/__init__.py
+++ b/case_exiftool/__init__.py
@@ -39,20 +39,20 @@ from case_utils.namespace import (
 
 _logger = logging.getLogger(os.path.basename(__file__))
 
-NS_EXIFTOOL_COMPOSITE = rdflib.Namespace("http://ns.exiftool.ca/Composite/1.0/")
-NS_EXIFTOOL_ET = rdflib.Namespace("http://ns.exiftool.ca/1.0/")
-NS_EXIFTOOL_EXIFTOOL = rdflib.Namespace("http://ns.exiftool.ca/ExifTool/1.0/")
-NS_EXIFTOOL_GPS = rdflib.Namespace("http://ns.exiftool.ca/EXIF/GPS/1.0/")
-NS_EXIFTOOL_SYSTEM = rdflib.Namespace("http://ns.exiftool.ca/File/System/1.0/")
-NS_EXIFTOOL_FILE = rdflib.Namespace("http://ns.exiftool.ca/File/1.0/")
-NS_EXIFTOOL_IFD0 = rdflib.Namespace("http://ns.exiftool.ca/EXIF/IFD0/1.0/")
-NS_EXIFTOOL_EXIFIFD = rdflib.Namespace("http://ns.exiftool.ca/EXIF/ExifIFD/1.0/")
-NS_EXIFTOOL_NIKON = rdflib.Namespace("http://ns.exiftool.ca/MakerNotes/Nikon/1.0/")
+NS_EXIFTOOL_COMPOSITE = rdflib.Namespace("http://ns.exiftool.org/Composite/1.0/")
+NS_EXIFTOOL_ET = rdflib.Namespace("http://ns.exiftool.org/1.0/")
+NS_EXIFTOOL_EXIFTOOL = rdflib.Namespace("http://ns.exiftool.org/ExifTool/1.0/")
+NS_EXIFTOOL_GPS = rdflib.Namespace("http://ns.exiftool.org/EXIF/GPS/1.0/")
+NS_EXIFTOOL_SYSTEM = rdflib.Namespace("http://ns.exiftool.org/File/System/1.0/")
+NS_EXIFTOOL_FILE = rdflib.Namespace("http://ns.exiftool.org/File/1.0/")
+NS_EXIFTOOL_IFD0 = rdflib.Namespace("http://ns.exiftool.org/EXIF/IFD0/1.0/")
+NS_EXIFTOOL_EXIFIFD = rdflib.Namespace("http://ns.exiftool.org/EXIF/ExifIFD/1.0/")
+NS_EXIFTOOL_NIKON = rdflib.Namespace("http://ns.exiftool.org/MakerNotes/Nikon/1.0/")
 NS_EXIFTOOL_PREVIEWIFD = rdflib.Namespace(
-    "http://ns.exiftool.ca/MakerNotes/PreviewIFD/1.0/"
+    "http://ns.exiftool.org/MakerNotes/PreviewIFD/1.0/"
 )
-NS_EXIFTOOL_INTEROPIFD = rdflib.Namespace("http://ns.exiftool.ca/EXIF/InteropIFD/1.0/")
-NS_EXIFTOOL_IFD1 = rdflib.Namespace("http://ns.exiftool.ca/EXIF/IFD1/1.0/")
+NS_EXIFTOOL_INTEROPIFD = rdflib.Namespace("http://ns.exiftool.org/EXIF/InteropIFD/1.0/")
+NS_EXIFTOOL_IFD1 = rdflib.Namespace("http://ns.exiftool.org/EXIF/IFD1/1.0/")
 
 argument_parser = argparse.ArgumentParser(epilog=__doc__)
 argument_parser.add_argument("--base-prefix", default="http://example.org/kb/")
@@ -136,7 +136,7 @@ class ExifToolRDFMapper(object):
     The implementation strategy is:
     * Iterating through an if-elif ladder of IRIs with known interpretation strategies; and
     * Lazily instantiating objects with class @property methods.
-    The lazy (or just-in-time) instantiation is because some graph objects can be needed for various reasons, but because of ExifTool's varied format coverage, it would not be appropriate to create each object each time.  For instance, on encountering GPS data in a JPEG's EXIF data (prefixes "http://ns.exiftool.ca/Composite/1.0/GPS", "http://ns.exiftool.ca/EXIF/GPS/1.0/GPS"), three things need to be created:
+    The lazy (or just-in-time) instantiation is because some graph objects can be needed for various reasons, but because of ExifTool's varied format coverage, it would not be appropriate to create each object each time.  For instance, on encountering GPS data in a JPEG's EXIF data (prefixes "http://ns.exiftool.org/Composite/1.0/GPS", "http://ns.exiftool.org/EXIF/GPS/1.0/GPS"), three things need to be created:
     * A Location object.
     * A derivation and assumption relationship between the original trace and the inferred Location object.
     * Entries in the EXIF dictionary.
@@ -182,7 +182,7 @@ class ExifToolRDFMapper(object):
         assert isinstance(n_exiftool_predicate, rdflib.URIRef)
         exiftool_iri = str(n_exiftool_predicate)
 
-        if exiftool_iri == "http://ns.exiftool.ca/Composite/1.0/GPSAltitude":
+        if exiftool_iri == "http://ns.exiftool.org/Composite/1.0/GPSAltitude":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 l_altitude = rdflib.Literal(v_raw.toPython(), datatype=NS_XSD.decimal)
@@ -193,7 +193,7 @@ class ExifToolRDFMapper(object):
                         l_altitude,
                     )
                 )
-        elif exiftool_iri == "http://ns.exiftool.ca/Composite/1.0/GPSLatitude":
+        elif exiftool_iri == "http://ns.exiftool.org/Composite/1.0/GPSLatitude":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 l_latitude = rdflib.Literal(v_raw.toPython(), datatype=NS_XSD.decimal)
@@ -204,7 +204,7 @@ class ExifToolRDFMapper(object):
                         l_latitude,
                     )
                 )
-        elif exiftool_iri == "http://ns.exiftool.ca/Composite/1.0/GPSLongitude":
+        elif exiftool_iri == "http://ns.exiftool.org/Composite/1.0/GPSLongitude":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 l_longitude = rdflib.Literal(v_raw.toPython(), datatype=NS_XSD.decimal)
@@ -215,11 +215,11 @@ class ExifToolRDFMapper(object):
                         l_longitude,
                     )
                 )
-        elif exiftool_iri == "http://ns.exiftool.ca/Composite/1.0/GPSPosition":
+        elif exiftool_iri == "http://ns.exiftool.org/Composite/1.0/GPSPosition":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_printconv, rdflib.Literal):
                 self.graph.add((self.n_location_object, NS_RDFS.label, v_printconv))
-        elif exiftool_iri == "http://ns.exiftool.ca/EXIF/ExifIFD/1.0/ExifImageHeight":
+        elif exiftool_iri == "http://ns.exiftool.org/EXIF/ExifIFD/1.0/ExifImageHeight":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 self.exif_dictionary_dict["Image Height"] = v_raw
@@ -230,7 +230,7 @@ class ExifToolRDFMapper(object):
                         rdflib.Literal(int(v_raw.toPython())),
                     )
                 )
-        elif exiftool_iri == "http://ns.exiftool.ca/EXIF/ExifIFD/1.0/ExifImageWidth":
+        elif exiftool_iri == "http://ns.exiftool.org/EXIF/ExifIFD/1.0/ExifImageWidth":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 self.exif_dictionary_dict["Image Width"] = v_raw
@@ -243,20 +243,20 @@ class ExifToolRDFMapper(object):
                         )
                     )
         elif exiftool_iri in {
-            "http://ns.exiftool.ca/EXIF/GPS/1.0/GPSAltitudeRef",
-            "http://ns.exiftool.ca/EXIF/GPS/1.0/GPSAltitude",
-            "http://ns.exiftool.ca/EXIF/GPS/1.0/GPSLatitudeRef",
-            "http://ns.exiftool.ca/EXIF/GPS/1.0/GPSLatitude",
-            "http://ns.exiftool.ca/EXIF/GPS/1.0/GPSLongitudeRef",
-            "http://ns.exiftool.ca/EXIF/GPS/1.0/GPSLongitude",
+            "http://ns.exiftool.org/EXIF/GPS/1.0/GPSAltitudeRef",
+            "http://ns.exiftool.org/EXIF/GPS/1.0/GPSAltitude",
+            "http://ns.exiftool.org/EXIF/GPS/1.0/GPSLatitudeRef",
+            "http://ns.exiftool.org/EXIF/GPS/1.0/GPSLatitude",
+            "http://ns.exiftool.org/EXIF/GPS/1.0/GPSLongitudeRef",
+            "http://ns.exiftool.org/EXIF/GPS/1.0/GPSLongitude",
         }:
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 dict_key = exiftool_iri.replace(
-                    "http://ns.exiftool.ca/EXIF/GPS/1.0/GPS", ""
+                    "http://ns.exiftool.org/EXIF/GPS/1.0/GPS", ""
                 )
                 self.exif_dictionary_dict[dict_key] = v_raw
-        elif exiftool_iri == "http://ns.exiftool.ca/EXIF/IFD0/1.0/Make":
+        elif exiftool_iri == "http://ns.exiftool.org/EXIF/IFD0/1.0/Make":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             printconv_str: typing.Optional[str] = None
             raw_str: typing.Optional[str] = None
@@ -275,19 +275,19 @@ class ExifToolRDFMapper(object):
                         n_manufacturer,
                     )
                 )
-        elif exiftool_iri == "http://ns.exiftool.ca/EXIF/IFD0/1.0/Model":
+        elif exiftool_iri == "http://ns.exiftool.org/EXIF/IFD0/1.0/Model":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 # TODO - If both values available and differ, map printconv to deviceType?
                 self.graph.add(
                     (self.n_camera_object_device_facet, NS_UCO_OBSERVABLE.model, v_raw)
                 )
-        elif exiftool_iri == "http://ns.exiftool.ca/File/1.0/MIMEType":
+        elif exiftool_iri == "http://ns.exiftool.org/File/1.0/MIMEType":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 self.mime_type = v_raw.toPython()
                 # Special case - graph logic is delayed for this IRI, because of needing to initialize the base ObservableObject based on the value.
-        elif exiftool_iri == "http://ns.exiftool.ca/File/System/1.0/FileAccessDate":
+        elif exiftool_iri == "http://ns.exiftool.org/File/System/1.0/FileAccessDate":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 self.graph.add(
@@ -300,7 +300,7 @@ class ExifToolRDFMapper(object):
                     )
                 )
         elif (
-            exiftool_iri == "http://ns.exiftool.ca/File/System/1.0/FileInodeChangeDate"
+            exiftool_iri == "http://ns.exiftool.org/File/System/1.0/FileInodeChangeDate"
         ):
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
@@ -313,7 +313,7 @@ class ExifToolRDFMapper(object):
                         ),
                     )
                 )
-        elif exiftool_iri == "http://ns.exiftool.ca/File/System/1.0/FileModifyDate":
+        elif exiftool_iri == "http://ns.exiftool.org/File/System/1.0/FileModifyDate":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 self.graph.add(
@@ -325,11 +325,11 @@ class ExifToolRDFMapper(object):
                         ),
                     )
                 )
-        elif exiftool_iri == "http://ns.exiftool.ca/File/System/1.0/FileName":
+        elif exiftool_iri == "http://ns.exiftool.org/File/System/1.0/FileName":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 self.graph.add((self.n_file_facet, NS_UCO_OBSERVABLE.fileName, v_raw))
-        elif exiftool_iri == "http://ns.exiftool.ca/File/System/1.0/FilePermissions":
+        elif exiftool_iri == "http://ns.exiftool.org/File/System/1.0/FilePermissions":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 raw = v_raw.toPython()
@@ -346,7 +346,7 @@ class ExifToolRDFMapper(object):
                 self.graph.add(
                     (self.n_unix_file_permissions_facet, NS_RDFS.comment, v_printconv)
                 )
-        elif exiftool_iri == "http://ns.exiftool.ca/File/System/1.0/FileSize":
+        elif exiftool_iri == "http://ns.exiftool.org/File/System/1.0/FileSize":
             (v_raw, v_printconv) = self.pop_n_exiftool_predicate(n_exiftool_predicate)
             if isinstance(v_raw, rdflib.Literal):
                 self.graph.add(
@@ -406,7 +406,7 @@ class ExifToolRDFMapper(object):
 
         # Start by mapping some IRIs that affect the base observable object.
         self.map_raw_and_printconv_iri(
-            rdflib.URIRef("http://ns.exiftool.ca/File/1.0/MIMEType")
+            rdflib.URIRef("http://ns.exiftool.org/File/1.0/MIMEType")
         )
 
         # Determine slug by MIME type.

--- a/tests/govdocs1/files/799/987/799987_printConv.xml
+++ b/tests/govdocs1/files/799/987/799987_printConv.xml
@@ -2,26 +2,26 @@
 <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
 
 <rdf:Description rdf:about='http://example.org/kb/govdocs1/799/799987.jpg'
-  xmlns:et='http://ns.exiftool.ca/1.0/' et:toolkit='Image::ExifTool 12.00'
-  xmlns:ExifTool='http://ns.exiftool.ca/ExifTool/1.0/'
-  xmlns:System='http://ns.exiftool.ca/File/System/1.0/'
-  xmlns:File='http://ns.exiftool.ca/File/1.0/'
-  xmlns:IFD0='http://ns.exiftool.ca/EXIF/IFD0/1.0/'
-  xmlns:ExifIFD='http://ns.exiftool.ca/EXIF/ExifIFD/1.0/'
-  xmlns:Nikon='http://ns.exiftool.ca/MakerNotes/Nikon/1.0/'
-  xmlns:PreviewIFD='http://ns.exiftool.ca/MakerNotes/PreviewIFD/1.0/'
-  xmlns:InteropIFD='http://ns.exiftool.ca/EXIF/InteropIFD/1.0/'
-  xmlns:GPS='http://ns.exiftool.ca/EXIF/GPS/1.0/'
-  xmlns:IFD1='http://ns.exiftool.ca/EXIF/IFD1/1.0/'
-  xmlns:Composite='http://ns.exiftool.ca/Composite/1.0/'>
- <ExifTool:ExifToolVersion>12.00</ExifTool:ExifToolVersion>
+  xmlns:et='http://ns.exiftool.org/1.0/' et:toolkit='Image::ExifTool 12.52'
+  xmlns:ExifTool='http://ns.exiftool.org/ExifTool/1.0/'
+  xmlns:System='http://ns.exiftool.org/File/System/1.0/'
+  xmlns:File='http://ns.exiftool.org/File/1.0/'
+  xmlns:IFD0='http://ns.exiftool.org/EXIF/IFD0/1.0/'
+  xmlns:ExifIFD='http://ns.exiftool.org/EXIF/ExifIFD/1.0/'
+  xmlns:Nikon='http://ns.exiftool.org/MakerNotes/Nikon/1.0/'
+  xmlns:PreviewIFD='http://ns.exiftool.org/MakerNotes/PreviewIFD/1.0/'
+  xmlns:InteropIFD='http://ns.exiftool.org/EXIF/InteropIFD/1.0/'
+  xmlns:GPS='http://ns.exiftool.org/EXIF/GPS/1.0/'
+  xmlns:IFD1='http://ns.exiftool.org/EXIF/IFD1/1.0/'
+  xmlns:Composite='http://ns.exiftool.org/Composite/1.0/'>
+ <ExifTool:ExifToolVersion>12.52</ExifTool:ExifToolVersion>
  <System:FileName>799987.jpg</System:FileName>
  <System:Directory>./799</System:Directory>
- <System:FileSize>1490 kB</System:FileSize>
+ <System:FileSize>1526 kB</System:FileSize>
  <System:FileModifyDate>2005:09:14 12:58:00-04:00</System:FileModifyDate>
  <System:FileAccessDate>2020:12:01 21:50:06-05:00</System:FileAccessDate>
  <System:FileInodeChangeDate>2020:12:01 21:50:06-05:00</System:FileInodeChangeDate>
- <System:FilePermissions>rw-r--r--</System:FilePermissions>
+ <System:FilePermissions>-rw-r--r--</System:FilePermissions>
  <File:FileType>JPEG</File:FileType>
  <File:FileTypeExtension>jpg</File:FileTypeExtension>
  <File:MIMEType>image/jpeg</File:MIMEType>
@@ -788,8 +788,11 @@ hVlVNqAKR08sgZ+uBmpsWj85aK+OP1EKKACigAooAKKACigAooAKKACigAoo
 A//Z
 </IFD1:ThumbnailImage>
  <Composite:Aperture>9.0</Composite:Aperture>
+ <Composite:BlueBalance>1.210938</Composite:BlueBalance>
  <Composite:ImageSize>3008x1960</Composite:ImageSize>
  <Composite:Megapixels>5.9</Composite:Megapixels>
+ <Composite:RedBalance>2.171875</Composite:RedBalance>
+ <Composite:ScaleFactor35efl>1.5</Composite:ScaleFactor35efl>
  <Composite:ShutterSpeed>1/320</Composite:ShutterSpeed>
  <Composite:SubSecCreateDate>2005:08:31 21:40:03.02</Composite:SubSecCreateDate>
  <Composite:SubSecDateTimeOriginal>2005:08:31 21:40:03.02</Composite:SubSecDateTimeOriginal>
@@ -799,14 +802,11 @@ A//Z
  <Composite:GPSLongitude>89 deg 19&#39; 3.00&quot; W</Composite:GPSLongitude>
  <Composite:LensID>AF-S VR Zoom-Nikkor 24-120mm f/3.5-5.6G IF-ED</Composite:LensID>
  <Composite:LensSpec>24-120mm f/3.5-5.6 G VR</Composite:LensSpec>
- <Composite:BlueBalance>1.210938</Composite:BlueBalance>
- <Composite:GPSPosition>30 deg 18&#39; 19.80&quot; N, 89 deg 19&#39; 3.00&quot; W</Composite:GPSPosition>
- <Composite:LightValue>13.7</Composite:LightValue>
- <Composite:RedBalance>2.171875</Composite:RedBalance>
- <Composite:ScaleFactor35efl>1.5</Composite:ScaleFactor35efl>
  <Composite:CircleOfConfusion>0.020 mm</Composite:CircleOfConfusion>
  <Composite:FOV>27.0 deg</Composite:FOV>
  <Composite:FocalLength35efl>50.0 mm (35 mm equivalent: 75.0 mm)</Composite:FocalLength35efl>
+ <Composite:GPSPosition>30 deg 18&#39; 19.80&quot; N, 89 deg 19&#39; 3.00&quot; W</Composite:GPSPosition>
  <Composite:HyperfocalDistance>13.87 m</Composite:HyperfocalDistance>
+ <Composite:LightValue>13.7</Composite:LightValue>
 </rdf:Description>
 </rdf:RDF>

--- a/tests/govdocs1/files/799/987/799987_raw.xml
+++ b/tests/govdocs1/files/799/987/799987_raw.xml
@@ -2,26 +2,26 @@
 <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
 
 <rdf:Description rdf:about='http://example.org/kb/govdocs1/799/799987.jpg'
-  xmlns:et='http://ns.exiftool.ca/1.0/' et:toolkit='Image::ExifTool 12.00'
-  xmlns:ExifTool='http://ns.exiftool.ca/ExifTool/1.0/'
-  xmlns:System='http://ns.exiftool.ca/File/System/1.0/'
-  xmlns:File='http://ns.exiftool.ca/File/1.0/'
-  xmlns:IFD0='http://ns.exiftool.ca/EXIF/IFD0/1.0/'
-  xmlns:ExifIFD='http://ns.exiftool.ca/EXIF/ExifIFD/1.0/'
-  xmlns:Nikon='http://ns.exiftool.ca/MakerNotes/Nikon/1.0/'
-  xmlns:PreviewIFD='http://ns.exiftool.ca/MakerNotes/PreviewIFD/1.0/'
-  xmlns:InteropIFD='http://ns.exiftool.ca/EXIF/InteropIFD/1.0/'
-  xmlns:GPS='http://ns.exiftool.ca/EXIF/GPS/1.0/'
-  xmlns:IFD1='http://ns.exiftool.ca/EXIF/IFD1/1.0/'
-  xmlns:Composite='http://ns.exiftool.ca/Composite/1.0/'>
- <ExifTool:ExifToolVersion>12.00</ExifTool:ExifToolVersion>
+  xmlns:et='http://ns.exiftool.org/1.0/' et:toolkit='Image::ExifTool 12.52'
+  xmlns:ExifTool='http://ns.exiftool.org/ExifTool/1.0/'
+  xmlns:System='http://ns.exiftool.org/File/System/1.0/'
+  xmlns:File='http://ns.exiftool.org/File/1.0/'
+  xmlns:IFD0='http://ns.exiftool.org/EXIF/IFD0/1.0/'
+  xmlns:ExifIFD='http://ns.exiftool.org/EXIF/ExifIFD/1.0/'
+  xmlns:Nikon='http://ns.exiftool.org/MakerNotes/Nikon/1.0/'
+  xmlns:PreviewIFD='http://ns.exiftool.org/MakerNotes/PreviewIFD/1.0/'
+  xmlns:InteropIFD='http://ns.exiftool.org/EXIF/InteropIFD/1.0/'
+  xmlns:GPS='http://ns.exiftool.org/EXIF/GPS/1.0/'
+  xmlns:IFD1='http://ns.exiftool.org/EXIF/IFD1/1.0/'
+  xmlns:Composite='http://ns.exiftool.org/Composite/1.0/'>
+ <ExifTool:ExifToolVersion>12.52</ExifTool:ExifToolVersion>
  <System:FileName>799987.jpg</System:FileName>
- <System:Directory>.</System:Directory>
+ <System:Directory>./799</System:Directory>
  <System:FileSize>1526008</System:FileSize>
  <System:FileModifyDate>2005:09:14 12:58:00-04:00</System:FileModifyDate>
  <System:FileAccessDate>2020:12:01 21:50:06-05:00</System:FileAccessDate>
  <System:FileInodeChangeDate>2020:12:01 21:50:06-05:00</System:FileInodeChangeDate>
- <System:FilePermissions>644</System:FilePermissions>
+ <System:FilePermissions>100644</System:FilePermissions>
  <File:FileType>JPEG</File:FileType>
  <File:FileTypeExtension>JPG</File:FileTypeExtension>
  <File:MIMEType>image/jpeg</File:MIMEType>

--- a/tests/govdocs1/files/799/987/analysis.json
+++ b/tests/govdocs1/files/799/987/analysis.json
@@ -1,17 +1,17 @@
 {
     "@context": {
-        "exiftool-Composite": "http://ns.exiftool.ca/Composite/1.0/",
-        "exiftool-ExifIFD": "http://ns.exiftool.ca/EXIF/ExifIFD/1.0/",
-        "exiftool-ExifTool": "http://ns.exiftool.ca/ExifTool/1.0/",
-        "exiftool-File": "http://ns.exiftool.ca/File/1.0/",
-        "exiftool-GPS": "http://ns.exiftool.ca/EXIF/GPS/1.0/",
-        "exiftool-IFD0": "http://ns.exiftool.ca/EXIF/IFD0/1.0/",
-        "exiftool-IFD1": "http://ns.exiftool.ca/EXIF/IFD1/1.0/",
-        "exiftool-InteropIFD": "http://ns.exiftool.ca/EXIF/InteropIFD/1.0/",
-        "exiftool-Nikon": "http://ns.exiftool.ca/MakerNotes/Nikon/1.0/",
-        "exiftool-PreviewIFD": "http://ns.exiftool.ca/MakerNotes/PreviewIFD/1.0/",
-        "exiftool-System": "http://ns.exiftool.ca/File/System/1.0/",
-        "exiftool-et": "http://ns.exiftool.ca/1.0/",
+        "exiftool-Composite": "http://ns.exiftool.org/Composite/1.0/",
+        "exiftool-ExifIFD": "http://ns.exiftool.org/EXIF/ExifIFD/1.0/",
+        "exiftool-ExifTool": "http://ns.exiftool.org/ExifTool/1.0/",
+        "exiftool-File": "http://ns.exiftool.org/File/1.0/",
+        "exiftool-GPS": "http://ns.exiftool.org/EXIF/GPS/1.0/",
+        "exiftool-IFD0": "http://ns.exiftool.org/EXIF/IFD0/1.0/",
+        "exiftool-IFD1": "http://ns.exiftool.org/EXIF/IFD1/1.0/",
+        "exiftool-InteropIFD": "http://ns.exiftool.org/EXIF/InteropIFD/1.0/",
+        "exiftool-Nikon": "http://ns.exiftool.org/MakerNotes/Nikon/1.0/",
+        "exiftool-PreviewIFD": "http://ns.exiftool.org/MakerNotes/PreviewIFD/1.0/",
+        "exiftool-System": "http://ns.exiftool.org/File/System/1.0/",
+        "exiftool-et": "http://ns.exiftool.org/1.0/",
         "kb": "http://example.org/kb/",
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
@@ -181,7 +181,7 @@
         {
             "@id": "kb:picture-41679402-5530-56a5-befe-fda477b006e5",
             "@type": "uco-observable:ObservableObject",
-            "exiftool-et:toolkit": "Image::ExifTool 12.00",
+            "exiftool-et:toolkit": "Image::ExifTool 12.52",
             "exiftool-Composite:Aperture": [
                 "9",
                 "9.0"
@@ -387,7 +387,7 @@
                 "R98 - DCF basic file (sRGB)"
             ],
             "exiftool-InteropIFD:InteropVersion": "0100",
-            "exiftool-ExifTool:ExifToolVersion": "12.00",
+            "exiftool-ExifTool:ExifToolVersion": "12.52",
             "exiftool-File:BitsPerSample": "8",
             "exiftool-File:ColorComponents": "3",
             "exiftool-File:EncodingProcess": [
@@ -409,10 +409,7 @@
                 "2 1",
                 "YCbCr4:2:2 (2 1)"
             ],
-            "exiftool-System:Directory": [
-                ".",
-                "./799"
-            ],
+            "exiftool-System:Directory": "./799",
             "exiftool-Nikon:AFAreaMode": [
                 "1",
                 "Dynamic Area"
@@ -591,10 +588,7 @@
         {
             "@id": "kb:unix-file-permissions-facet-752e9d1c-2a7e-5f67-9c34-17cfd2b78d22",
             "@type": "uco-observable:UNIXFilePermissionsFacet",
-            "rdfs:comment": [
-                "644",
-                "rw-r--r--"
-            ]
+            "rdfs:comment": "-rw-r--r--"
         }
     ]
 }

--- a/tests/govdocs1/files/799/987/analysis.ttl
+++ b/tests/govdocs1/files/799/987/analysis.ttl
@@ -1,15 +1,15 @@
-@prefix exiftool-Composite: <http://ns.exiftool.ca/Composite/1.0/> .
-@prefix exiftool-ExifIFD: <http://ns.exiftool.ca/EXIF/ExifIFD/1.0/> .
-@prefix exiftool-ExifTool: <http://ns.exiftool.ca/ExifTool/1.0/> .
-@prefix exiftool-File: <http://ns.exiftool.ca/File/1.0/> .
-@prefix exiftool-GPS: <http://ns.exiftool.ca/EXIF/GPS/1.0/> .
-@prefix exiftool-IFD0: <http://ns.exiftool.ca/EXIF/IFD0/1.0/> .
-@prefix exiftool-IFD1: <http://ns.exiftool.ca/EXIF/IFD1/1.0/> .
-@prefix exiftool-InteropIFD: <http://ns.exiftool.ca/EXIF/InteropIFD/1.0/> .
-@prefix exiftool-Nikon: <http://ns.exiftool.ca/MakerNotes/Nikon/1.0/> .
-@prefix exiftool-PreviewIFD: <http://ns.exiftool.ca/MakerNotes/PreviewIFD/1.0/> .
-@prefix exiftool-System: <http://ns.exiftool.ca/File/System/1.0/> .
-@prefix exiftool-et: <http://ns.exiftool.ca/1.0/> .
+@prefix exiftool-Composite: <http://ns.exiftool.org/Composite/1.0/> .
+@prefix exiftool-ExifIFD: <http://ns.exiftool.org/EXIF/ExifIFD/1.0/> .
+@prefix exiftool-ExifTool: <http://ns.exiftool.org/ExifTool/1.0/> .
+@prefix exiftool-File: <http://ns.exiftool.org/File/1.0/> .
+@prefix exiftool-GPS: <http://ns.exiftool.org/EXIF/GPS/1.0/> .
+@prefix exiftool-IFD0: <http://ns.exiftool.org/EXIF/IFD0/1.0/> .
+@prefix exiftool-IFD1: <http://ns.exiftool.org/EXIF/IFD1/1.0/> .
+@prefix exiftool-InteropIFD: <http://ns.exiftool.org/EXIF/InteropIFD/1.0/> .
+@prefix exiftool-Nikon: <http://ns.exiftool.org/MakerNotes/Nikon/1.0/> .
+@prefix exiftool-PreviewIFD: <http://ns.exiftool.org/MakerNotes/PreviewIFD/1.0/> .
+@prefix exiftool-System: <http://ns.exiftool.org/File/System/1.0/> .
+@prefix exiftool-et: <http://ns.exiftool.org/1.0/> .
 @prefix kb: <http://example.org/kb/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -133,7 +133,7 @@ kb:location-87e04bf8-27ed-5209-9d19-753c65ce28a3
 
 kb:picture-41679402-5530-56a5-befe-fda477b006e5
 	a uco-observable:ObservableObject ;
-	exiftool-et:toolkit "Image::ExifTool 12.00" ;
+	exiftool-et:toolkit "Image::ExifTool 12.52" ;
 	exiftool-Composite:Aperture
 		"9" ,
 		"9.0"
@@ -336,7 +336,7 @@ kb:picture-41679402-5530-56a5-befe-fda477b006e5
 		"R98 - DCF basic file (sRGB)"
 		;
 	exiftool-InteropIFD:InteropVersion "0100" ;
-	exiftool-ExifTool:ExifToolVersion "12.00" ;
+	exiftool-ExifTool:ExifToolVersion "12.52" ;
 	exiftool-File:BitsPerSample "8" ;
 	exiftool-File:ColorComponents "3" ;
 	exiftool-File:EncodingProcess
@@ -358,10 +358,7 @@ kb:picture-41679402-5530-56a5-befe-fda477b006e5
 		"2 1" ,
 		"YCbCr4:2:2 (2 1)"
 		;
-	exiftool-System:Directory
-		"." ,
-		"./799"
-		;
+	exiftool-System:Directory "./799" ;
 	exiftool-Nikon:AFAreaMode
 		"1" ,
 		"Dynamic Area"
@@ -514,9 +511,6 @@ kb:relationship-08e45f3c-8d7d-5034-a19e-f4f6e1f06b17
 
 kb:unix-file-permissions-facet-752e9d1c-2a7e-5f67-9c34-17cfd2b78d22
 	a uco-observable:UNIXFilePermissionsFacet ;
-	rdfs:comment
-		"644" ,
-		"rw-r--r--"
-		;
+	rdfs:comment "-rw-r--r--" ;
 	.
 


### PR DESCRIPTION
The main reason for this patch is the change of the RDF namespace prefixes from `ns.exiftool.ca` to `ns.exiftool.org` with version 12.26.

This patch series regenerates the ExifTool output on the govdocs1 sample. One manual edit-pattern was applied: File system timestamps were preserved from the prior Git-tracked state.  Otherwise, the results are as generated.

References:
* https://exiftool.org/ancient_history.html#v12.26