### PR TITLE
Relax pre-commit supply chain review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,36 @@ check-supply-chain: \
   check-supply-chain-pre-commit
 
 # This target is scheduled to run as part of prerelease review.
+# Update pre-commit configuration and use the updated config file to
+# review code.  Only have Make exit if 'pre-commit run' modifies files.
 check-supply-chain-pre-commit: \
   .venv-pre-commit/var/.pre-commit-built.log
 	source .venv-pre-commit/bin/activate \
 	  && pre-commit autoupdate
 	git diff \
 	  --exit-code \
-	  .pre-commit-config.yaml
+	  .pre-commit-config.yaml \
+	  || ( \
+	      source .venv-pre-commit/bin/activate \
+	        && pre-commit run \
+	          --all-files \
+	          --config .pre-commit-config.yaml \
+	    ) \
+	    || git diff \
+	      --exit-code \
+	      --stat \
+	      || ( \
+	          echo \
+	            "WARNING:Makefile:pre-commit configuration can be updated.  It appears the update would change file formatting." \
+	            >&2 \
+	            ; exit 1 \
+                )
+	@git diff \
+	  --exit-code \
+	  .pre-commit-config.yaml \
+	  || echo \
+	    "INFO:Makefile:pre-commit configuration can be updated.  It appears the update would not change file formatting." \
+	    >&2
 
 clean:
 	@rm -rf \


### PR DESCRIPTION
This patch was the intended effect of `90318a5`, but I'd missed `git add`'ing the changes to `/Makefile`.