### PR TITLE
Remove prior `license_files` section

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@ version = attr: case_exiftool.__version__
 author = Alex Nelson
 author_email = alexander.nelson@nist.gov
 description = A mapping of ExifTool to CASE
-license_files = LICENSE
 #TODO - PyPI will need a differently-written README.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This was supposed to have been replaced in #68 .  Running the command locally revealed the issue.